### PR TITLE
Add Fathom script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -65,6 +65,9 @@
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | prepend: site.baseurl }}">
 <link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl }}">
 
+<!-- Fathom Analytics -->
+<script src="https://cdn.usefathom.com/script.js" data-site="WHLLFEUT" defer></script>
+
 {% if site.google_analytics %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Integrates Fathom into the site by loading their script from the shared `head` include so page views can be measured in a privacy-friendly way.